### PR TITLE
Move to next mc event, fov offset and verbosity when opening file

### DIFF
--- a/pyhessio/__init__.py
+++ b/pyhessio/__init__.py
@@ -2,7 +2,7 @@ import numpy as np
 import os
 import ctypes
 
-__all__ = ['move_to_next_event','file_open','close_file',
+__all__ = ['move_to_next_event','move_to_next_mc_event','file_open','close_file',
            'get_global_event_count','get_run_number',
            'get_num_telescope','get_telescope_with_data_list',
            'get_teldata_list', 'get_telescope_position',
@@ -71,6 +71,8 @@ lib.get_telescope_position.argtypes=[ctypes.c_int,np.ctypeslib.ndpointer(ctypes.
 lib.get_telescope_position.restype=ctypes.c_int
 lib.move_to_next_event.argtypes = [np.ctypeslib.ndpointer(ctypes.c_int)]
 lib.move_to_next_event.restype = ctypes.c_int
+lib.move_to_next_mc_event.argtypes = [np.ctypeslib.ndpointer(ctypes.c_int)]
+lib.move_to_next_mc_event.restype = ctypes.c_int
 lib.get_mc_event_xcore.restype = ctypes.c_double
 lib.get_mc_event_ycore.restype = ctypes.c_double
 lib.get_mc_shower_energy.restype = ctypes.c_double
@@ -149,6 +151,31 @@ def move_to_next_event(limit=0):
         if res != -1:
             yield res, result[0]
             evt_num = evt_num + 1
+
+def move_to_next_mc_event(limit=0):
+    """
+    Read data form input file
+    and fill corresponding container
+    Data can be then access with
+    other available functions in
+    this module.
+    This iterator scans all the simulated events,
+    not only the triggered ones.
+    By default all events are computed
+
+    Parameters
+    ----------
+    limit: int,optional
+        limit allows to limit the number of event generated
+    """
+    result = np.zeros(1, dtype=np.int32)
+    res = 0
+    sim_evt_num = 0
+    while res >= 0 and (limit == 0 or sim_evt_num < limit):
+        res = lib.move_to_next_mc_event(result)
+        if res != -1:
+            yield res, result[0]
+            sim_evt_num = sim_evt_num + 1
 
 def file_open(filename):
     """

--- a/pyhessio/__init__.py
+++ b/pyhessio/__init__.py
@@ -9,7 +9,7 @@ __all__ = ['move_to_next_event','move_to_next_mc_event','file_open','close_file'
            'get_num_teldata','get_num_channel','get_num_pixels',
            'get_num_samples','get_adc_sample','get_adc_sum',
            'get_pedestal','get_calibration','get_pixel_position',
-           'get_pixel_timing_timval','get_mirror_area', 'get_focal_length',
+           'get_pixel_timing_timval','get_mirror_area',
            'get_pixel_timing_num_times_types',
            'get_pixel_timing_threshold','get_pixel_timing_peak_global',
            'get_mc_shower_primary_id','get_mc_shower_h_first_int',
@@ -43,8 +43,6 @@ lib.get_pedestal.restype=ctypes.c_int
 lib.get_global_event_count.restype = ctypes.c_int
 lib.get_mirror_area.argtypes = [ctypes.c_int,np.ctypeslib.ndpointer(ctypes.c_double, flags="C_CONTIGUOUS")]
 lib.get_mirror_area.restype = ctypes.c_int
-lib.get_focal_length.argtypes = [ctypes.c_int,np.ctypeslib.ndpointer(ctypes.c_double, flags="C_CONTIGUOUS")]
-lib.get_focal_length.restype = ctypes.c_int
 lib.get_num_channel.argtypes = [ctypes.c_int]
 lib.get_num_channel.restype = ctypes.c_int
 lib.get_num_pixels.argtypes = [ctypes.c_int]
@@ -288,33 +286,6 @@ def get_mirror_area(telescope_id):
         raise(HessioTelescopeIndexError("no telescope with id " + str(telescope_id)))
     raise(HessioGeneralError("hsdata->camera_set[itel].mirror_area not available"))
 
-def get_focal_length(telescope_id):
-    """
-    Returns
-    -------
-    focal length of optics [m]
-    
-    Parameters
-    ----------
-    telescope_id: int
-    
-    Raises
-    ------
-    HessioGeneralError
-    if hsdata->camera_set[itel].flen not available
-
-    HessioTelescopeIndexError
-    if no telescope exist with this id
-    """
-    
-    data = np.zeros(1,dtype=np.double)
-    result = lib.get_focal_length(telescope_id,data)
-    if result == 0:
-        return data[0]
-    elif result == TEL_INDEX_NOT_VALID:
-        raise(HessioTelescopeIndexError("no telescope with id " + str(telescope_id))) 
-    raise(HessioGeneralError("hsdata->camera_set[itel].flen not available"))
-
 def get_telescope_with_data_list():
     """
     Returns
@@ -398,7 +369,7 @@ def get_num_teldata():
     """
 
     number =  lib.get_num_teldata()
-    if number > 0:
+    if number >= 0:
         return number
     else:
         raise(HessioGeneralError("hsdata->event.num_teldata is not available"))
@@ -968,9 +939,7 @@ def get_time_slice(telescope_id):
     """
     return lib.get_time_slice(telescope_id)
 
-
-
-def  get_tel_event_gps_time(telescope_id):
+def get_tel_event_gps_time(telescope_id):
     """
     Returns:
     --------
@@ -991,7 +960,7 @@ def  get_tel_event_gps_time(telescope_id):
         raise(HessioGeneralError("no event gps time for telescope "))
 
 
-def  get_central_event_gps_time():
+def get_central_event_gps_time():
     """
     Returns:
     --------
@@ -1049,7 +1018,7 @@ def get_mirror_number(telescope_id):
     result = lib.get_mirror_number(telescope_id)
     if result >= 0 : return result
     elif result == TEL_INDEX_NOT_VALID:
-        raise(HessioTelescopeIndexError("no telescope wth id " + str(telescope_id))) 
+        raise(HessioTelescopeIndexError("no telescope with id " + str(telescope_id))) 
     else:
         raise(HessioGeneralError("hsdata->camera_set[itel].num_mirrors not available"))
 
@@ -1059,7 +1028,7 @@ def get_optical_foclen(telescope_id):
     """
     Returns
     -------
-    focal length ofoptics of a telescope [m]
+    focal length of optics of a telescope [m]
 
     Parameters
     ----------
@@ -1077,7 +1046,7 @@ def get_optical_foclen(telescope_id):
     result = lib.get_optical_foclen(telescope_id)
     if result >=0 : return result
     elif result == TEL_INDEX_NOT_VALID:
-        raise(HessioTelescopeIndexError("no telescope wth id " + str(telescope_id))) 
+        raise(HessioTelescopeIndexError("no telescope with id " + str(telescope_id))) 
     else:
         raise(HessioGeneralError("hsdata->camera_set[itel].flen not available"))
 

--- a/pyhessio/__init__.py
+++ b/pyhessio/__init__.py
@@ -14,6 +14,7 @@ __all__ = ['move_to_next_event','move_to_next_mc_event','file_open','close_file'
            'get_pixel_timing_threshold','get_pixel_timing_peak_global',
            'get_mc_shower_primary_id','get_mc_shower_h_first_int',
            'get_mc_event_xcore', 'get_mc_event_ycore' ,'get_mc_shower_energy',
+           'get_mc_event_offset_fov',
            'get_mc_shower_azimuth' ,'get_mc_shower_altitude','get_adc_known',
            'get_ref_shape' ,'get_ref_step','get_time_slice',
            'get_ref_shapes',  'get_nrefshape' ,'get_lrefshape',
@@ -75,6 +76,8 @@ lib.move_to_next_mc_event.argtypes = [np.ctypeslib.ndpointer(ctypes.c_int)]
 lib.move_to_next_mc_event.restype = ctypes.c_int
 lib.get_mc_event_xcore.restype = ctypes.c_double
 lib.get_mc_event_ycore.restype = ctypes.c_double
+lib.get_mc_event_offset_fov.argtypes = [np.ctypeslib.ndpointer(ctypes.c_double, flags="C_CONTIGUOUS")]
+lib.get_mc_event_offset_fov.restype = ctypes.c_int
 lib.get_mc_shower_energy.restype = ctypes.c_double
 lib.get_mc_shower_azimuth.restype = ctypes.c_double
 lib.get_mc_shower_altitude.restype = ctypes.c_double
@@ -804,6 +807,28 @@ def get_mc_event_ycore():
     y -> W
     """
     return  lib.get_mc_event_ycore()
+
+def get_mc_event_offset_fov():
+    """
+    Returns
+    -------
+    offset of pointing direction in camera f.o.v.
+    divided by focal length, i.e. converted to radians:
+      [0] = Camera x (downwards in normal pointing, i.e. increasing Alt)
+      [1] = Camera y -> Az.
+
+    Raises
+    ------
+    HessioGeneralError
+    if information is not available
+    """
+    offset = np.zeros(2,dtype=np.double)
+    
+    result = lib.get_mc_event_offset_fov(offset)
+    if result == 0:
+        return offset
+    else:
+        raise(HessioGeneralError("hsdata is not available"))
 
 def get_mc_shower_energy():
     """

--- a/pyhessio/src/pyhessio.c
+++ b/pyhessio/src/pyhessio.c
@@ -37,6 +37,7 @@ int get_telescope_with_data_list (int *list);
 int get_telescope_position (int telescope_id, double *pos);
 int get_telescope_index (int telescope_id);
 int move_to_next_event (int *event_id);
+int move_to_next_mc_event (int *event_id);
 double get_mc_event_xcore (void);
 double get_mc_event_ycore (void);
 double get_mc_shower_energy (void);
@@ -141,6 +142,30 @@ move_to_next_event (int *event_id)
 	  close_file ();
 	  return -1;
 	}
+    }
+  return get_run_number ();
+}
+
+//----------------------------------
+//Read input file and fill hsdata
+// and item_header global var
+//Scan all simulated events
+//----------------------------------
+int
+move_to_next_mc_event (int *event_id)
+{
+  if (!file_is_opened)
+    return -1;
+
+  int rc = 0;
+  while (rc != IO_TYPE_HESS_MC_EVENT)
+    {
+      rc = fill_hsdata (event_id);
+      if (rc < 0)
+        {
+          close_file ();
+          return -1;
+        }
     }
   return get_run_number ();
 }
@@ -1145,7 +1170,7 @@ fill_hsdata (int *event_id)	//,int *header_readed)
       /* =================================================== */
     case IO_TYPE_HESS_MC_EVENT:
       rc = read_hess_mc_event (iobuf, &(hsdata)->mc_event);
-
+      *event_id = item_header.ident;
       break;
       /* =================================================== */
     case IO_TYPE_MC_TELARRAY:

--- a/pyhessio/src/pyhessio.c
+++ b/pyhessio/src/pyhessio.c
@@ -40,6 +40,7 @@ int move_to_next_event (int *event_id);
 int move_to_next_mc_event (int *event_id);
 double get_mc_event_xcore (void);
 double get_mc_event_ycore (void);
+int get_mc_event_offset_fov (double *off);
 double get_mc_shower_energy (void);
 double get_mc_shower_azimuth (void);
 double get_mc_shower_altitude (void);
@@ -599,6 +600,26 @@ get_mc_event_ycore ()
       return hsdata->mc_event.ycore;
     }
   return -0.;
+}
+
+//----------------------------------------------------------------
+// Returns the offset of pointing direction in camera f.o.v.
+// divided by focal length, i.e. converted to radians:
+//   [0] = Camera x (downwards in normal pointing, i.e. increasing Alt)
+//   [1] = Camera y -> Az.
+// -1 if hsdata == NULL
+//----------------------------------------------------------------
+int
+get_mc_event_offset_fov (double *off)
+{
+  if (hsdata != NULL)
+    {
+      int loop = 0;
+      for (loop = 0; loop < 2; ++loop)  // loop over coordinates
+        *off++ = hsdata->run_header.offset_fov[loop];
+      return 0;
+    }
+  return -1;
 }
 
 //-------------------------------------------

--- a/pyhessio/src/pyhessio.c
+++ b/pyhessio/src/pyhessio.c
@@ -21,7 +21,6 @@ int get_pedestal (int telescope_id, double *pedestal);
 int get_calibration (int telescope_id, double *calib);
 int get_global_event_count (void);
 int get_mirror_area (int telescope_id, double *mirror_area);
-int get_focal_length(int telescope_id, double* result);
 int get_num_channel (int telescope_id);
 int get_num_pixels (int telescope_id);
 int get_num_samples (int telescope_id);
@@ -835,23 +834,6 @@ get_mirror_area (int telescope_id, double *result)
       return 0;
     }
   return -1.;
-}
-
-//----------------------------------------------------------------
-// Returns the focal length of optics [m]
-// Returns TEL_INDEX_NOT_VALID if telescope index is not valid
-//----------------------------------------------------------------
-int
-get_focal_length(int telescope_id, double* result)
-{
-  if (hsdata != NULL && result != NULL)
-    {
-      int itel = get_telescope_index(telescope_id);
-      if (itel == TEL_INDEX_NOT_VALID) return TEL_INDEX_NOT_VALID;
-      *result = hsdata->camera_set[itel].flen;
-      return 0;
-    }
-  return -1;
 }
 
 //-----------------------------------------------------

--- a/pyhessio/src/pyhessio.c
+++ b/pyhessio/src/pyhessio.c
@@ -115,9 +115,9 @@ file_open (const char *filename)
 	    return -1;
 	  }
 
-    fflush (stdout);
-    fprintf (stderr, "%s\n", filename);
-    printf ("\nInput file '%s' has been opened.\n", filename);
+    // fflush (stdout);
+    // fprintf (stderr, "%s\n", filename);
+    // printf ("\nInput file '%s' has been opened.\n", filename);
     file_is_opened = 1;
   }
   return 0;
@@ -996,7 +996,7 @@ fill_hsdata (int *event_id)	//,int *header_readed)
 	  Warning ("Reading run header failed.");
 	  exit (1);
 	}
-      fprintf (stderr, "\nStarting run %d\n", (hsdata)->run_header.run);
+      // fprintf (stderr, "\nStarting run %d\n", (hsdata)->run_header.run);
       for (itel = 0; itel <= (hsdata)->run_header.ntel; itel++)
 	{
 

--- a/pyhessio/tests/test_hessio.py
+++ b/pyhessio/tests/test_hessio.py
@@ -12,6 +12,7 @@ except ImportError as err:
 def test_hessio():
     """
     v move_to_next_event(limit=0):
+    v move_to_next_mc_event(limit=0):
     v file_open(filename):
     close_file():
     v get_global_event_count():
@@ -35,6 +36,10 @@ def test_hessio():
     v get_mirror_number(telescope_id)
     v get_optical_foclen(telescope_id)
     v get_telescope_ids()
+    v get_mc_shower_primary_id()
+    v get_mc_shower_h_first_int()
+    v get_telescope_position(telescope_id)
+    v get_mc_event_offset_fov()
     """
     tel_id = 47
     channel = 0
@@ -47,8 +52,9 @@ def test_hessio():
     
     # test reading file
     assert file_open("/home/jacquem/workspace/data/gamma_20deg_0deg_run31964___cta-prod2_desert-1640m-Aar.simtel.gz") == 0 
-    #assert file_open("/afs/ifh.de/user/z/zornju/gamma_20deg_0deg_run31964___cta-prod2_desert-1640m-Aar.simtel.gz") == 0  
-    
+    #assert file_open("/afs/ifh.de/user/z/zornju/gamma_20deg_0deg_run31964___cta-prod2_desert-1640m-Aar.simtel.gz") == 0
+    #assert file_open("/home/michele/Software/pyhessioxxx/gamma_20deg_0deg_run31964___cta-prod2_desert-1640m-Aar.simtel") == 0 
+
     #for run_id, event_id in move_to_next_event(limit = 1):
         
     run_id, event_id = next(move_to_next_event())
@@ -113,7 +119,7 @@ def test_hessio():
     
     
     
-    #get_num_sampple
+    #get_num_sample
     nb_sample = get_num_samples(tel_id) 
     assert nb_sample == 25
     try: 
@@ -147,9 +153,6 @@ def test_hessio():
         get_pixel_position(0)
         assert()
     except HessioTelescopeIndexError: pass
-        
-        
-        
     
     assert(np.array_equal(get_telescope_with_data_list() , [38, 47]) == True)
 
@@ -203,8 +206,20 @@ def test_hessio():
         assert()
     except HessioTelescopeIndexError: pass
 
+    # Telescope position
+    tel_x, tel_y, tel_z = get_telescope_position(tel_id)
+    assert(float( tel_x ) == float(1223.800048828125))
+    assert(float( tel_y ) == float(704.0999755859375))
+    assert(float( tel_z ) == float(5.0))
+    try:
+        get_telescope_position(-1)
+        assert()
+    except HessioTelescopeIndexError: pass
 
-       
+    mc_offset_x, mc_offset_y = get_mc_event_offset_fov()
+    assert( mc_offset_x == 0)
+    assert( mc_offset_y == 0)
+
     """
     xcode 1129.6055908203125
     ycode 547.77001953125
@@ -229,7 +244,10 @@ def test_hessio():
     assert(float(get_mc_shower_energy()) == float(.3820943236351013))
     assert(float(get_mc_shower_azimuth()) == float(6.283185005187988))
     assert(float(get_mc_shower_altitude()) == float( 1.2217304706573486))
-    
+
+    assert(get_mc_shower_primary_id() == 0)
+    assert(float(get_mc_shower_h_first_int()) == float(17846.654296875))
+
     assert(get_adc_known(38,0,1000)== 1 )
 
     assert(float(get_ref_shape(38,0,2)) == float(.0269622802734375))
@@ -283,6 +301,28 @@ lref_shape 80
 
     close_file()
     
-        
+    assert file_open("/home/jacquem/workspace/data/gamma_20deg_0deg_run31964___cta-prod2_desert-1640m-Aar.simtel.gz") == 0 
+    #assert file_open("/home/michele/Software/pyhessioxxx/gamma_20deg_0deg_run31964___cta-prod2_desert-1640m-Aar.simtel") == 0 
+    
+    # Testing move_to_next_mc_event iterator
+    run_id, event_id = next(move_to_next_mc_event())
+    
+    assert run_id == 31964
+    assert event_id == 100 # Different from before
+
+    # Configuration is the same
+    assert len(get_telescope_ids()) == 126
+    assert get_telescope_ids()[100] == 101
+    
+    # now we don't have any telescope data
+    assert(get_num_teldata() == 0)
+
+    # but we have simulation data
+    assert(get_mc_shower_primary_id() == 0)
+    assert(float(get_mc_event_xcore()) == float(-591.63360595703125))
+    assert(float(get_mc_event_ycore()) == float(1080.77392578125))
+    
+    close_file()
+
 if __name__ == "__main__":
     test_hessio()


### PR DESCRIPTION
Having to read all the simulated events (not only the triggered ones) I added the `move_to_next_mc_event` iterator.

I also added a getter to obtain the offset of pointing direction in camera f.o.v.

To retrieve the information I need, I didn't find other ways than reopening the file (triggering a new filling of hsdata struct, one with HESS_EVENT, once with HESS_MC_EVENT). Multiple messages about opening the input were shown. I removed the messages also because I think having the assert is sufficient to be sure that the operation went well. Maybe it is possible to add a verbosity parameter to that function triggering or not the messages. You can drop this modification if you prefer, this is very low importance.
Thanks,
Michele