### PR TITLE
handle memory allocation error for AllHessData

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+
+*.o
+
+*.so
+
+build/lib.macosx-10.5-x86_64-3.5/pyhessio/__init__.py

--- a/pyhessio/src/pyhessio.c
+++ b/pyhessio/src/pyhessio.c
@@ -841,6 +841,10 @@ int fill_hsdata (int *event_id)	//,int *header_readed)
 				free_hsdata();
 			}
 			hsdata = (AllHessData *) calloc (1, sizeof (AllHessData));
+			if (hsdata == NULL) {
+			        Warning ("Memory Allocation Failed. Please free up RAM");
+				exit (1);
+			}
 			if ((rc = read_hess_runheader (iobuf, &(hsdata)->run_header)) < 0){
 				Warning ("Reading run header failed.");
 				exit (1);


### PR DESCRIPTION
added a better error message if the `AllHessData` stuct cannot be allocated (before it would complain about a missing RunHeader, but that is really incorrect)