### PR TITLE
Changed where num_channels is extracted from

### DIFF
--- a/pyhessio/__init__.py
+++ b/pyhessio/__init__.py
@@ -555,7 +555,7 @@ class HessioFile:
 
         Raises
         ------
-        HessioGeneralError: when hsdata->event.teldata[itel].raw
+        HessioGeneralError: when hsdata->camera_org[itel].num_gains
         HessioTelescopeIndexError: when no telescope exist with this id
         """
         result = self.lib.get_num_channel(telescope_id)

--- a/pyhessio/__init__.py
+++ b/pyhessio/__init__.py
@@ -121,8 +121,8 @@ class HessioFile:
         self.lib.get_num_channel.restype = ctypes.c_int
         self.lib.get_num_pixels.argtypes = [ctypes.c_int]
         self.lib.get_num_pixels.restype = ctypes.c_int
-        self.lib.get_num_samples.argtypes = [ctypes.c_int]
-        self.lib.get_num_samples.restype = ctypes.c_int
+        self.lib.get_event_num_samples.argtypes = [ctypes.c_int]
+        self.lib.get_event_num_samples.restype = ctypes.c_int
         self.lib.get_zero_sup_mode.argtypes = [ctypes.c_int,
                                           np.ctypeslib.ndpointer(ctypes.c_int,
                                                                  flags="C_CONTIGUOUS")]
@@ -708,9 +708,12 @@ class HessioFile:
                                     "significant not available for telescope " +
                                     str(telescope_id)))
 
-    def get_num_samples(self, telescope_id):
+    def get_event_num_samples(self, telescope_id):
         """
-        Returns the number of samples (time slices) recorded
+        Returns the number of samples (time slices) recorded.
+        Only contains the number of samples for the telescopes that have
+        data in the current event.
+
         Parameters
         ----------
         telescope_id : int
@@ -721,7 +724,7 @@ class HessioFile:
          available
         HessioTelescopeIndexError: when no telescope exist with this id
         """
-        result = self.lib.get_num_samples(telescope_id)
+        result = self.lib.get_event_num_samples(telescope_id)
         if result >= 0: return result
         elif result == TEL_INDEX_NOT_VALID:
             raise(HessioTelescopeIndexError("no telescope with id " +
@@ -803,7 +806,7 @@ class HessioFile:
         """
         n_chan = self.get_num_channel(telescope_id)
         n_pix = self.get_num_pixels(telescope_id)
-        n_samples = self.get_num_samples(telescope_id)
+        n_samples = self.get_event_num_samples(telescope_id)
 
         if not n_samples > 0:
             return np.zeros(0)

--- a/pyhessio/src/pyhessio.c
+++ b/pyhessio/src/pyhessio.c
@@ -22,7 +22,7 @@ int get_global_event_count (void);
 int get_mirror_area (int telescope_id, double *mirror_area);
 int get_num_channel (int telescope_id);
 int get_num_pixels (int telescope_id);
-int get_num_samples (int telescope_id);
+int get_event_num_samples (int telescope_id);
 int get_zero_sup_mode(int telescope_id,int* result);
 int get_data_red_mode(int telescope_id,int* result);
 int get_num_teldata (void);
@@ -866,11 +866,13 @@ int  get_mirror_area (int telescope_id, double *result)
 	return -1.;
 }
 //-----------------------------------------------------
-// Returns the number of samples (time slices) recorded
+// Returns the number of samples (time slices) recorded.
+// Only contains the number of samples for the telescopes that have
+// data in the current event.
 // Returns TEL_INDEX_NOT_VALID if telescope index is not valid
 // Otherwise 0
 //-----------------------------------------------------
-int get_num_samples (int telescope_id)
+int get_event_num_samples (int telescope_id)
 {
 	if (hsdata != NULL)
 		{

--- a/pyhessio/src/pyhessio.c
+++ b/pyhessio/src/pyhessio.c
@@ -304,18 +304,16 @@ int get_central_event_gps_time (long *seconds, long *nanoseconds){
 // Returns the number of different gains per pixel for a telscope id
 // Returns TEL_INDEX_NOT_VALID if telescope index is not valid
 //----------------------------------------------------------------
-int get_num_channel (int telescope_id){
-if (hsdata != NULL)
-	{
+int get_num_channel (int telescope_id)
+{
+	if (hsdata != NULL)
+		{
 		int itel = get_telescope_index (telescope_id);
 		if (itel == TEL_INDEX_NOT_VALID)
-			return TEL_INDEX_NOT_VALID;
-		AdcData *raw = hsdata->event.teldata[itel].raw;
-		if (raw != NULL && raw->known){
-			return raw->num_gains;
+		return TEL_INDEX_NOT_VALID;
+		return hsdata->camera_org[itel].num_gains;
 		}
-	}
-return -1;
+	return -1;
 }
 //----------------------------------------------------------------
 // Returns Width of readout time slice (i.e. one sample) [ns].

--- a/pyhessio/tests/test_hessio.py
+++ b/pyhessio/tests/test_hessio.py
@@ -78,11 +78,6 @@ def test_hessio():
             raise
         except HessioTelescopeIndexError:
             pass
-        try:
-            hessio.get_num_channel(1)
-            raise
-        except HessioGeneralError:
-            pass
 
         assert set(hessio.get_teldata_list()) == set([38, 47])
 

--- a/pyhessio/tests/test_hessio.py
+++ b/pyhessio/tests/test_hessio.py
@@ -19,7 +19,7 @@ def test_hessio():
     v get_num_teldata():
     v get_num_channel(telescope_id):
     v get_num_pixels(telescope_id):
-    v get_num_samples(telescope_id):
+    v get_event_num_samples(telescope_id):
     v get_zero_sup_mode(telescope_id):
     v get_data_red_mode(telescope_id):
     v get_adc_sample(telescope_id):
@@ -115,11 +115,11 @@ def test_hessio():
         except HessioTelescopeIndexError:
             pass
 
-        #get_num_sample
-        nb_sample = hessio.get_num_samples(tel_id)
+        #get_event_num_samples
+        nb_sample = hessio.get_event_num_samples(tel_id)
         assert nb_sample == 25
         try:
-            hessio.get_num_samples(70000)
+            hessio.get_event_num_samples(70000)
             raise
         except HessioTelescopeIndexError:
             pass

--- a/pyhessio/tests/test_hessio.py
+++ b/pyhessio/tests/test_hessio.py
@@ -22,8 +22,8 @@ def test_hessio():
     v get_num_samples(telescope_id):
     v get_zero_sup_mode(telescope_id):
     v get_data_red_mode(telescope_id):
-    v get_adc_sample(telescope_id,channel):
-    v get_adc_sum(telescope_id,channel):
+    v get_adc_sample(telescope_id):
+    v get_adc_sum(telescope_id):
     v get_significant(telescope_id):
     v get_data_for_calibration(telescope_id):
     v get_pixel_position(telescope_id):
@@ -90,19 +90,13 @@ def test_hessio():
             pass
 
         #get_adc_sample
-        data_ch = hessio.get_adc_sample(tel_id, channel)
+        data_ch = hessio.get_adc_sample(tel_id)[channel]
         assert np.array_equal(data_ch[10:11],[[22,20,21,24,22,19,22,27,22,21,20,22,21,20,19,22,23,20,22,20,20,23,20,20,22]]) == True
 
         try:
-            hessio.get_adc_sample(-1, 0)
+            data_ch = hessio.get_adc_sample(-1)[channel]
             raise
         except HessioTelescopeIndexError: pass
-
-        try:
-            data_ch = hessio.get_adc_sample(47, 5)
-            raise
-        except HessioChannelIndexError:
-            pass
 
         #get_significant
         data_sig = hessio.get_significant(tel_id)
@@ -110,23 +104,16 @@ def test_hessio():
         assert np.array_equal(data_sig, model) is True
 
         #get_adc_sum
-        data_ch_sum = hessio.get_adc_sum(tel_id,channel)
+        data_ch_sum = hessio.get_adc_sum(tel_id)[channel]
         assert np.array_equal(data_ch_sum[0:10], [451, 550, 505, 465, 519,
                                                   467, 505, 496, 501, 478]) \
                is True
 
         try:
-            data_ch_sum = hessio.get_adc_sum(-1, channel)
+            data_ch_sum = hessio.get_adc_sum(-1)[channel]
             raise
         except HessioTelescopeIndexError:
             pass
-
-        try:
-            data_ch_sum = hessio.get_adc_sum(47, 2)
-            raise
-        except HessioChannelIndexError: pass
-
-
 
         #get_num_sample
         nb_sample = hessio.get_num_samples(tel_id)
@@ -336,7 +323,7 @@ def test_hessio():
 
         """
 
-        ref_shapes = hessio.get_ref_shapes(38, 0)
+        ref_shapes = hessio.get_ref_shapes(38)[channel]
         assert(float(ref_shapes[0]) == float(0.01372528076171875))
         assert(float(ref_shapes[79]) == float(0.0009870529174804688))
         assert(hessio.get_nrefshape(38) == 1)


### PR DESCRIPTION
Change get_num_channels to extract from hsdata->camera_org[itel].num_gains instead of hsdata->event.teldata[itel].raw, allowing it to be extracted regardless if data exists for that telescope in the current event