### PR TITLE
Trigger pixels

### DIFF
--- a/pyhessio/__init__.py
+++ b/pyhessio/__init__.py
@@ -125,6 +125,12 @@ class HessioFile:
         self.lib.get_num_channel.restype = ctypes.c_int
         self.lib.get_num_pixels.argtypes = [ctypes.c_int]
         self.lib.get_num_pixels.restype = ctypes.c_int
+        self.lib.get_num_trig_pixels.argtypes = [ctypes.c_int]
+        self.lib.get_num_trig_pixels.restype = ctypes.c_int
+        self.lib.get_trig_pixels.argtypes = [ctypes.c_int,
+                                                     np.ctypeslib.ndpointer(ctypes.c_int32,
+                                                         flags="C_CONTIGUOUS")]
+        self.lib.get_trig_pixels.restype = ctypes.c_int
         self.lib.get_event_num_samples.argtypes = [ctypes.c_int]
         self.lib.get_event_num_samples.restype = ctypes.c_int
         self.lib.get_zero_sup_mode.argtypes = [ctypes.c_int,
@@ -626,6 +632,60 @@ class HessioFile:
         else:
             raise(HessioGeneralError("hsdata->camera_set[itel]."
                                      "num_pixels not available"))
+
+    def get_num_trig_pixels(self, telescope_id):
+        """
+        Parameters
+        ----------
+        int:
+            telescope_id: telescope's id
+        Returns
+        -------
+        int:
+            the number of trigger pixels in the camera
+
+        Raises
+        ------
+        HessioGeneralError: when hsdata->camera_set[itel].num_pixels
+        HessioTelescopeIndexError: when no telescope exist with this id
+        """
+        result = self.lib.get_num_trig_pixels(telescope_id)
+        if result >= 0 :
+            return result
+        elif result == TEL_INDEX_NOT_VALID:
+            raise(HessioTelescopeIndexError("no telescope with id " +
+                                            str(telescope_id)))
+        else:
+            raise(HessioGeneralError("hsdata->camera_set[itel]."
+                                     "num_pixels not available"))
+
+    def get_trig_pixels(self, telescope_id):
+        """
+        Parameters
+        ----------
+        int:
+            telescope_id: telescope's id
+        Returns
+        -------
+        int:
+            the list of trigger pixels in the camera
+
+        Raises
+        ------
+        HessioGeneralError: when hsdata->camera_set[itel].num_pixels
+        HessioTelescopeIndexError: when no telescope exist with this id
+        """
+        npix = self.get_num_trig_pixels(telescope_id)
+        trig_pixels = np.zeros(npix, dtype=np.int32)
+        result = self.lib.get_trig_pixels(telescope_id,trig_pixels)
+        if result == 0:
+            return trig_pixels
+        elif result == TEL_INDEX_NOT_VALID:
+            raise(HessioTelescopeIndexError("no telescope with id " +
+                                            str(telescope_id)))
+        else:
+            raise(HessioGeneralError("no pixel trigger for telescope "
+                                     + str(telescope_id)))
 
     def get_pixel_timing_threshold(self, telescope_id):
         """

--- a/pyhessio/src/pyhessio.c
+++ b/pyhessio/src/pyhessio.c
@@ -1212,6 +1212,10 @@ int get_num_pixels (int telescope_id)
 	return -1;
 }
 
+//----------------------------------------------------------------
+// Returns the number of pixels used in the camera trigger
+// Returns TEL_INDEX_NOT_VALID if telescope index is not valid
+//----------------------------------------------------------------
 int get_num_trig_pixels (int telescope_id)
 {
 	if (hsdata != NULL)

--- a/pyhessio/src/pyhessio.c
+++ b/pyhessio/src/pyhessio.c
@@ -1240,7 +1240,8 @@ int get_trig_pixels (int telescope_id, int *trigpix)
 		    if (itel == TEL_INDEX_NOT_VALID)
                 return TEL_INDEX_NOT_VALID;
             int npix = hsdata->event.teldata[itel].trigger_pixels.pixels;
-            for (int ipix=0.; ipix < npix; ipix++)
+            int ipix = 0;
+            for (ipix=0.; ipix < npix; ipix++)
             {
                 *trigpix++ = hsdata->event.teldata[itel].trigger_pixels.pixel_list[ipix];
             }

--- a/pyhessio/src/pyhessio.c
+++ b/pyhessio/src/pyhessio.c
@@ -22,6 +22,8 @@ int get_global_event_count (void);
 int get_mirror_area (int telescope_id, double *mirror_area);
 int get_num_channel (int telescope_id);
 int get_num_pixels (int telescope_id);
+int get_num_trig_pixels (int telescope_id);
+int get_trig_pixels (int telescope_id, int *trigpix);
 int get_event_num_samples (int telescope_id);
 int get_zero_sup_mode(int telescope_id,int* result);
 int get_data_red_mode(int telescope_id,int* result);
@@ -1209,6 +1211,40 @@ int get_num_pixels (int telescope_id)
 		}
 	return -1;
 }
+
+int get_num_trig_pixels (int telescope_id)
+{
+	if (hsdata != NULL)
+		{
+		    int itel = get_telescope_index (telescope_id);
+		    if (itel == TEL_INDEX_NOT_VALID)
+                return TEL_INDEX_NOT_VALID;
+            return hsdata->event.teldata[itel].trigger_pixels.pixels;
+		}
+    return -1;
+}
+
+//----------------------------------------------------------------
+// Returns a list of pixels used in the camera trigger
+// Returns TEL_INDEX_NOT_VALID if telescope index is not valid
+//----------------------------------------------------------------
+int get_trig_pixels (int telescope_id, int *trigpix)
+{
+	if (hsdata != NULL)
+		{
+		    int itel = get_telescope_index (telescope_id);
+		    if (itel == TEL_INDEX_NOT_VALID)
+                return TEL_INDEX_NOT_VALID;
+            int npix = hsdata->event.teldata[itel].trigger_pixels.pixels;
+            for (int ipix=0.; ipix < npix; ipix++)
+            {
+                *trigpix++ = hsdata->event.teldata[itel].trigger_pixels.pixel_list[ipix];
+            }
+            return 0;
+        }
+    return -1;
+}
+
 //----------------------------------------------------------------
 // Returns total area of individual mirrors corrected   for inclination [m^2].
 // Returns TEL_INDEX_NOT_VALID if telescope index is not valid

--- a/pyhessio/tests/test_hessio.py
+++ b/pyhessio/tests/test_hessio.py
@@ -89,7 +89,9 @@ def test_hessio():
         except HessioTelescopeIndexError:
             pass
 
-
+        # test the trigger data
+        assert (hessio.get_num_trig_pixels(tel_id) == 3)
+        assert (np.array_equal(hessio.get_trig_pixels(tel_id), [68, 1242, 1338]) == True)
 
         #get_significant
         data_sig = hessio.get_significant(tel_id)
@@ -328,12 +330,6 @@ def test_hessio():
         assert(hessio.get_mc_shower_primary_id() == 0)
         assert(float(hessio.get_mc_event_xcore()) == float(-591.63360595703125))
         assert(float(hessio.get_mc_event_ycore()) == float(1080.77392578125))
-
-        # test the trigger data
-        assert(hessio.get_num_trig_pixels(tel_id) == 3)
-        assert(np.array_equal(hessio.get_trig_pixels(tel_id), [68, 1242, 1338]) == True)
-
-
 
         close_file()
 

--- a/pyhessio/tests/test_hessio.py
+++ b/pyhessio/tests/test_hessio.py
@@ -329,6 +329,12 @@ def test_hessio():
         assert(float(hessio.get_mc_event_xcore()) == float(-591.63360595703125))
         assert(float(hessio.get_mc_event_ycore()) == float(1080.77392578125))
 
+        # test the trigger data
+        assert(hessio.get_num_trig_pixels(tel_id) == 3)
+        assert(np.array_equal(hessio.get_trig_pixels(tel_id), [68, 1242, 1338]) == True)
+
+
+
         close_file()
 
 


### PR DESCRIPTION
Slight modification to allow trigger pixel id's to be read from the MC data. This is driven by future studies on muon flagging, where the simplest method to search for muon like events in uncalibrated data is to look at the position of the triggered pixels.