### PR TITLE
added new functionality to read sim_telarray calibration events

### DIFF
--- a/pyhessio/__init__.py
+++ b/pyhessio/__init__.py
@@ -189,6 +189,9 @@ class HessioFile:
         self.lib.move_to_next_mc_event.argtypes = [
             np.ctypeslib.ndpointer(ctypes.c_int)]
         self.lib.move_to_next_mc_event.restype = ctypes.c_int
+        self.lib.move_to_next_calib_event.argtypes = [
+            np.ctypeslib.ndpointer(ctypes.c_int)]
+        self.lib.move_to_next_calib_event.restype = ctypes.c_int
         self.lib.get_mc_event_xcore.restype = ctypes.c_double
         self.lib.get_mc_event_ycore.restype = ctypes.c_double
         self.lib.get_mc_run_array_direction.argtypes = [
@@ -381,6 +384,36 @@ class HessioFile:
         sim_evt_num = 0
         while run_id >= 0 and (limit == 0 or sim_evt_num < limit):
             run_id = self.lib.move_to_next_mc_event(result)
+            if run_id != -1:
+                yield result[0]
+                sim_evt_num += 1
+
+    def move_to_next_calib_event(self, limit=0):
+        """
+        Read calibration data form input file and fill corresponding container
+        Data can be then access with other available functions in
+        this module.
+        This iterator scans all the simulated events, not only the triggered
+        ones. By default all events are computed
+
+        Parameters
+        ----------
+        limit: int, optional
+            limit the number of event generated
+        Yields
+        ------
+          event id
+        Raises
+        ------
+        HessioError: When input file is not open
+        """
+        if not self.__opened_filename:
+            raise HessioError('input file is not open')
+        result = np.zeros(1, dtype=np.int32)
+        run_id = 0
+        sim_evt_num = 0
+        while run_id >= 0 and (limit == 0 or sim_evt_num < limit):
+            run_id = self.lib.move_to_next_calib_event(result)
             if run_id != -1:
                 yield result[0]
                 sim_evt_num += 1

--- a/pyhessio/__init__.py
+++ b/pyhessio/__init__.py
@@ -11,7 +11,7 @@ from enum import Enum
 
 __all__ = ['HessioError', 'HessioChannelIndexError',
            'HessioTelescopeIndexError', 'HessioGeneralError',
-           'HessioFile', 'open_hessio', 'close_file']
+           'HessioFile', 'open_hessio', 'close_file', 'EventType' ]
 
 __version__ = '2.0.1'
 

--- a/pyhessio/__init__.py
+++ b/pyhessio/__init__.py
@@ -7,6 +7,7 @@ import numpy as np
 import os
 import ctypes
 from contextlib import contextmanager
+from enum import Enum
 
 __all__ = ['HessioError', 'HessioChannelIndexError',
            'HessioTelescopeIndexError', 'HessioGeneralError',
@@ -17,9 +18,18 @@ __version__ = '2.0.1'
 TEL_INDEX_NOT_VALID = -2
 PIXEL_INDEX_NOT_VALID = -3
 
-
-
-
+class EventType(Enum):
+    """
+    Event type definition
+    ----------
+    follows definition in hessioxxx/include/io_hess.h
+    ----------
+    Default: CHERENKOV
+    """
+    CHERENKOV = 2010
+    PEDESTAL = 2028
+    LASER = 2023
+    MC = 2021
 
 class HessioError(Exception):
     pass
@@ -35,7 +45,6 @@ class HessioTelescopeIndexError(HessioError):
 
 class HessioChannelIndexError(HessioError):
     pass
-
 
 @contextmanager
 def open_hessio(filename):
@@ -186,12 +195,6 @@ class HessioFile:
         self.lib.get_telescope_position.restype = ctypes.c_int
         self.lib.move_to_next_event.argtypes = [np.ctypeslib.ndpointer(ctypes.c_int)]
         self.lib.move_to_next_event.restype = ctypes.c_int
-        self.lib.move_to_next_mc_event.argtypes = [
-            np.ctypeslib.ndpointer(ctypes.c_int)]
-        self.lib.move_to_next_mc_event.restype = ctypes.c_int
-        self.lib.move_to_next_calib_event.argtypes = [
-            np.ctypeslib.ndpointer(ctypes.c_int)]
-        self.lib.move_to_next_calib_event.restype = ctypes.c_int
         self.lib.get_mc_event_xcore.restype = ctypes.c_double
         self.lib.get_mc_event_ycore.restype = ctypes.c_double
         self.lib.get_mc_run_array_direction.argtypes = [
@@ -294,10 +297,11 @@ class HessioFile:
             np.ctypeslib.ndpointer(ctypes.c_int, flags="C_CONTIGUOUS")]
         self.lib.get_telescope_ids.restype = ctypes.c_int
 
-    def fill_next_event(self):
+    def fill_next_event(self, event_type = EventType.CHERENKOV.value ):
         """
         Fill corresponding container with the next event in file.
         Data can be then access with other available functions in this module
+        event_type can be CHERENKOV, MC, PEDESTAL, LASER
         Returns
         -------
         event_number
@@ -306,18 +310,18 @@ class HessioFile:
         HessioError: when error occurs while reading next event
         """
         event_number = np.zeros(1, dtype=np.int32)
-        run_id = self.lib.move_to_next_event(event_number)
+        run_id = self.lib.move_to_next_event(event_number, event_type)
         if run_id == -1 or event_number[0] == -1:
             raise HessioError("Error while reading next event")
         return event_number[0]
 
-    def move_to_next_event(self, limit=0):
+    def move_to_next_event(self, limit=0, event_type = EventType.CHERENKOV.value ):
         """
         Read data from input file and fill corresponding container.
         Data can be then access with other available functions in
         this module.
+        event_type can be CHERENKOV, MC, PEDESTAL, LASER
         By default all events are computed
-
 
         Parameters
         ----------
@@ -336,87 +340,10 @@ class HessioFile:
         run_id = 0
         evt_num = 0
         while run_id >= 0 and (limit == 0 or evt_num < limit):
-            run_id = self.lib.move_to_next_event(result)
+            run_id = self.lib.move_to_next_event(result, event_type)
             if run_id != -1:
                 yield result[0]
                 evt_num += 1
-
-    def fill_next_mc_event(self):
-        """
-        Fill corresponding container with the next MC event in file.
-        Data can be then access with other available functions in this module
-        Returns
-        -------
-        event_number
-        Raises
-        ------
-        HessioError: when error occurs while reading next event
-        """
-        event_number = np.zeros(1, dtype=np.int32)
-        run_id = self.lib.move_to_next_mc_event(event_number)
-        if run_id == -1 or event_number == -1:
-            raise HessioError("Error while reading next event")
-        return event_number[0]
-
-    def move_to_next_mc_event(self, limit=0):
-        """
-        Read MC data form input file and fill corresponding container
-        Data can be then access with other available functions in
-        this module.
-        This iterator scans all the simulated events, not only the triggered
-        ones. By default all events are computed
-
-        Parameters
-        ----------
-        limit: int, optional
-            limit the number of event generated
-        Yields
-        ------
-          event id
-        Raises
-        ------
-        HessioError: When input file is not open
-        """
-        if not self.__opened_filename:
-            raise HessioError('input file is not open')
-        result = np.zeros(1, dtype=np.int32)
-        run_id = 0
-        sim_evt_num = 0
-        while run_id >= 0 and (limit == 0 or sim_evt_num < limit):
-            run_id = self.lib.move_to_next_mc_event(result)
-            if run_id != -1:
-                yield result[0]
-                sim_evt_num += 1
-
-    def move_to_next_calib_event(self, limit=0):
-        """
-        Read calibration data form input file and fill corresponding container
-        Data can be then access with other available functions in
-        this module.
-        This iterator scans all the simulated events, not only the triggered
-        ones. By default all events are computed
-
-        Parameters
-        ----------
-        limit: int, optional
-            limit the number of event generated
-        Yields
-        ------
-          event id
-        Raises
-        ------
-        HessioError: When input file is not open
-        """
-        if not self.__opened_filename:
-            raise HessioError('input file is not open')
-        result = np.zeros(1, dtype=np.int32)
-        run_id = 0
-        sim_evt_num = 0
-        while run_id >= 0 and (limit == 0 or sim_evt_num < limit):
-            run_id = self.lib.move_to_next_calib_event(result)
-            if run_id != -1:
-                yield result[0]
-                sim_evt_num += 1
 
     def open_file(self, filename):
         """

--- a/pyhessio/src/pyhessio.c
+++ b/pyhessio/src/pyhessio.c
@@ -42,7 +42,7 @@ int get_run_number (void);
 int get_telescope_with_data_list (int *list);
 int get_telescope_position (int telescope_id, double *pos);
 int get_telescope_index (int telescope_id);
-int move_to_next_event (int *event_id);
+int move_to_next_event (int *event_id, int event_type );
 int move_to_next_mc_event (int *event_id);
 int move_to_next_calib_event (int *event_id);
 double get_mc_event_xcore (void);
@@ -160,16 +160,16 @@ int file_open (const char *filename){
 //Read input file and fill hsdata
 // and item_header global var
 //----------------------------------
-int move_to_next_event (int *event_id){
+int move_to_next_event (int *event_id, int event_type ){
 	if (!file_is_opened)
 		return -1;
 	int rc = 0;
-	while (rc != IO_TYPE_HESS_EVENT){
+	while (rc != event_type){
 		rc = fill_hsdata (event_id);
 		if (rc < 0){
 			return -1;
 		}
-	}
+	} 
 	return get_run_number ();
 }
 //----------------------------------

--- a/pyhessio/src/pyhessio.c
+++ b/pyhessio/src/pyhessio.c
@@ -44,6 +44,7 @@ int get_telescope_position (int telescope_id, double *pos);
 int get_telescope_index (int telescope_id);
 int move_to_next_event (int *event_id);
 int move_to_next_mc_event (int *event_id);
+int move_to_next_calib_event (int *event_id);
 double get_mc_event_xcore (void);
 double get_mc_event_ycore (void);
 int get_mc_run_array_direction (double *dir);
@@ -180,6 +181,20 @@ int move_to_next_mc_event (int *event_id){
 	if (!file_is_opened) return -1;
 	int rc = 0;
 	while (rc != IO_TYPE_HESS_MC_EVENT)	{
+		rc = fill_hsdata (event_id);
+		if (rc < 0){
+			return -1;
+		}
+	}
+	return get_run_number ();
+}
+//----------------------------------
+// Scan all calibration events
+//----------------------------------
+int move_to_next_calib_event (int *event_id){
+	if (!file_is_opened) return -1;
+	int rc = 0;
+	while (rc != IO_TYPE_HESS_CALIBEVENT)	{
 		rc = fill_hsdata (event_id);
 		if (rc < 0){
 			return -1;
@@ -1628,7 +1643,9 @@ int fill_hsdata (int *event_id)	//,int *header_readed)
 		/* =================================================== */
 		case IO_TYPE_HESS_CALIBEVENT:
 		{
-			printf ("RDLR: CALIBEVENT!\n");
+                        int type = -1;
+			rc = read_hess_calib_event(iobuf, &(hsdata)->event, -1, &type);
+			*event_id = item_header.ident;
 		}
 		break;
 		/* =================================================== */

--- a/pyhessio/tests/test_hessio.py
+++ b/pyhessio/tests/test_hessio.py
@@ -312,7 +312,7 @@ def test_hessio():
         hessio.open_file("pyhessio-extra/datasets/gamma_test.simtel.gz")
         # Testing move_to_next_mc_event iterator
         #event_id = next(hessio.move_to_next_mc_event())
-        event_id = hessio.fill_next_event( hessio.EventType.MC.value )
+        event_id = hessio.fill_next_event( EventType.MC.value )
         run_number = hessio.get_run_number()
 
         assert run_number == 31964

--- a/pyhessio/tests/test_hessio.py
+++ b/pyhessio/tests/test_hessio.py
@@ -312,7 +312,7 @@ def test_hessio():
         hessio.open_file("pyhessio-extra/datasets/gamma_test.simtel.gz")
         # Testing move_to_next_mc_event iterator
         #event_id = next(hessio.move_to_next_mc_event())
-        event_id = hessio.fill_next_event( EventType.MC.value )
+        event_id = hessio.fill_next_event( hessio.EventType.MC.value )
         run_number = hessio.get_run_number()
 
         assert run_number == 31964

--- a/pyhessio/tests/test_hessio.py
+++ b/pyhessio/tests/test_hessio.py
@@ -9,7 +9,6 @@ def test_hessio():
     v move_to_next_event(limit=0):
     v move_to_next_mc_event(limit=0):
     v fill_next_event
-    v fill_next_mc_event
     v open_file(filename):
     v close_file():
     v get_global_event_count():
@@ -313,7 +312,7 @@ def test_hessio():
         hessio.open_file("pyhessio-extra/datasets/gamma_test.simtel.gz")
         # Testing move_to_next_mc_event iterator
         #event_id = next(hessio.move_to_next_mc_event())
-        event_id = hessio.fill_next_mc_event()
+        event_id = hessio.fill_next_event( EventType.MC.value )
         run_number = hessio.get_run_number()
 
         assert run_number == 31964


### PR DESCRIPTION
New functionality to read sim_telarray calibration events.

Example:

```
with open_hessio('gamma_20deg_180deg_run4___cta-prod3-demo_desert-2150m-Paranal-baseline.simtel') as event:
   for event_id in event.move_to_next_calib_event(limit=5):
        print('run id {}:, event number: {}'.format(event.get_run_number() , event_id))
        print('    Triggered telescopes for this event: {}'.format(event.get_telescope_with_data_list()))
        print('    balkds {}'.format(event.get_adc_sample(5)))
```

This allows to read out the files with NSB events only.