### PR TITLE
Introduced function count_mc_generated_events

### DIFF
--- a/example.ipynb
+++ b/example.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
     "collapsed": true
    },
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -63,19 +63,14 @@
      "output_type": "stream",
      "text": [
       "run id 31964:, event number: 408\n",
-      "    run num showers:  100000\n",
       "    Triggered telescopes for this event: [38 47]\n",
       "run id 31964:, event number: 409\n",
-      "    run num showers:  100000\n",
       "    Triggered telescopes for this event: [ 11  21  24  26  61  63 118 119]\n",
       "run id 31964:, event number: 803\n",
-      "    run num showers:  100000\n",
       "    Triggered telescopes for this event: [ 17 104 124]\n",
       "run id 31964:, event number: 4907\n",
-      "    run num showers:  100000\n",
       "    Triggered telescopes for this event: [ 1  2  4 14 15 17 19]\n",
       "run id 31964:, event number: 9508\n",
-      "    run num showers:  100000\n",
       "    Triggered telescopes for this event: [ 2  3  4 10 12 25]\n"
      ]
     }
@@ -84,7 +79,6 @@
     "with open_hessio('pyhessio-extra/datasets/gamma_test.simtel.gz') as event:\n",
     "    for event_id in event.move_to_next_event(limit=5):\n",
     "        print('run id {}:, event number: {}'.format(event.get_run_number() , event_id))\n",
-    "        print('    run num showers: ', event.get_mc_num_showers())\n",
     "        print('    Triggered telescopes for this event: {}'.format(event.get_telescope_with_data_list()))"
    ]
   },
@@ -97,7 +91,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -147,7 +141,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -193,7 +187,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -203,7 +197,7 @@
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-8-7b55eccd11cd>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      3\u001b[0m     \u001b[0;32mwhile\u001b[0m \u001b[0mnb_read_event\u001b[0m \u001b[0;34m<\u001b[0m \u001b[0;36m10\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m         \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 5\u001b[0;31m             \u001b[0mevent_id\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mevent\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfill_next_mc_event\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      6\u001b[0m             \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'run id {}:, event number: {}'\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mformat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mevent\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_run_number\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m,\u001b[0m \u001b[0mevent_id\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      7\u001b[0m             \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'    Shower energy: {}'\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mformat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mevent\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_mc_shower_energy\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m<ipython-input-7-7b55eccd11cd>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      3\u001b[0m     \u001b[0;32mwhile\u001b[0m \u001b[0mnb_read_event\u001b[0m \u001b[0;34m<\u001b[0m \u001b[0;36m10\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m         \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 5\u001b[0;31m             \u001b[0mevent_id\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mevent\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfill_next_mc_event\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      6\u001b[0m             \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'run id {}:, event number: {}'\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mformat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mevent\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_run_number\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m,\u001b[0m \u001b[0mevent_id\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      7\u001b[0m             \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'    Shower energy: {}'\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mformat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mevent\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_mc_shower_energy\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
       "\u001b[0;31mAttributeError\u001b[0m: 'HessioFile' object has no attribute 'fill_next_mc_event'"
      ]
     }

--- a/example.ipynb
+++ b/example.ipynb
@@ -6,48 +6,76 @@
    "source": [
     "# pyhessio notebook example\n",
     "\n",
-    "## It is madatory to open hessio MC file with pyhessio context manager.\n",
+    "## It is mandatory to open hessio MC file with pyhessio context manager.\n",
     "This notebook shows 2 differents ways of looping over data and 2 differents ways of looping over MC data"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
    "outputs": [],
    "source": [
-    "from pyhessio import open_hessio, HessioError"
+    "from pyhessio import open_hessio, HessioError, count_mc_generated_events"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### loop ever the 5 first events using generator function move_to_next_event"
+    "### Get the number of simulated events (including re-uses of showers):"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "400000\n"
+     ]
+    }
+   ],
+   "source": [
+    "NumEvents = count_mc_generated_events('pyhessio-extra/datasets/gamma_test_large.simtel.gz')\n",
+    "print(NumEvents)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### loop over the 5 first events using generator function move_to_next_event"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "run id 31964:, event number: 408\n",
+      "    run num showers:  100000\n",
       "    Triggered telescopes for this event: [38 47]\n",
       "run id 31964:, event number: 409\n",
+      "    run num showers:  100000\n",
       "    Triggered telescopes for this event: [ 11  21  24  26  61  63 118 119]\n",
       "run id 31964:, event number: 803\n",
+      "    run num showers:  100000\n",
       "    Triggered telescopes for this event: [ 17 104 124]\n",
       "run id 31964:, event number: 4907\n",
+      "    run num showers:  100000\n",
       "    Triggered telescopes for this event: [ 1  2  4 14 15 17 19]\n",
       "run id 31964:, event number: 9508\n",
+      "    run num showers:  100000\n",
       "    Triggered telescopes for this event: [ 2  3  4 10 12 25]\n"
      ]
     }
@@ -56,6 +84,7 @@
     "with open_hessio('pyhessio-extra/datasets/gamma_test.simtel.gz') as event:\n",
     "    for event_id in event.move_to_next_event(limit=5):\n",
     "        print('run id {}:, event number: {}'.format(event.get_run_number() , event_id))\n",
+    "        print('    run num showers: ', event.get_mc_num_showers())\n",
     "        print('    Triggered telescopes for this event: {}'.format(event.get_telescope_with_data_list()))"
    ]
   },
@@ -63,15 +92,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### loop ever event using function fill_next_event and catch HessioError Exception "
+    "### loop over event using function fill_next_event and catch HessioError Exception "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 10,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -115,46 +142,42 @@
     "collapsed": true
    },
    "source": [
-    "### loop ever the 10 first MC events using generator function move_to_next_event "
+    "### loop over the 10 first MC events using generator function move_to_next_event "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 11,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "run id 31964:, event number: 100\n",
-      "    Shower energy: 0.003922517877072096\n",
-      "run id 31964:, event number: 101\n",
-      "    Shower energy: 0.003922517877072096\n",
-      "run id 31964:, event number: 102\n",
-      "    Shower energy: 0.003922517877072096\n",
-      "run id 31964:, event number: 103\n",
-      "    Shower energy: 0.003922517877072096\n",
-      "run id 31964:, event number: 104\n",
-      "    Shower energy: 0.003922517877072096\n",
-      "run id 31964:, event number: 105\n",
-      "    Shower energy: 0.003922517877072096\n",
-      "run id 31964:, event number: 106\n",
-      "    Shower energy: 0.003922517877072096\n",
-      "run id 31964:, event number: 107\n",
-      "    Shower energy: 0.003922517877072096\n",
-      "run id 31964:, event number: 108\n",
-      "    Shower energy: 0.003922517877072096\n",
-      "run id 31964:, event number: 109\n",
-      "    Shower energy: 0.003922517877072096\n"
+      "run id 31964:, event number: 408\n",
+      "    Shower energy: 0.3820943236351013\n",
+      "run id 31964:, event number: 409\n",
+      "    Shower energy: 0.3820943236351013\n",
+      "run id 31964:, event number: 803\n",
+      "    Shower energy: 0.2217816561460495\n",
+      "run id 31964:, event number: 4907\n",
+      "    Shower energy: 0.06210866943001747\n",
+      "run id 31964:, event number: 9508\n",
+      "    Shower energy: 0.06830974668264389\n",
+      "run id 31964:, event number: 10104\n",
+      "    Shower energy: 0.08499287813901901\n",
+      "run id 31964:, event number: 10109\n",
+      "    Shower energy: 0.08499287813901901\n",
+      "run id 31964:, event number: 11905\n",
+      "    Shower energy: 0.02509460598230362\n",
+      "run id 31964:, event number: 12202\n",
+      "    Shower energy: 0.6279199719429016\n"
      ]
     }
    ],
    "source": [
     "with open_hessio('pyhessio-extra/datasets/gamma_test.simtel.gz') as event:\n",
-    "    for event_id in event.move_to_next_mc_event(limit=10):\n",
+    "    for event_id in event.move_to_next_event(limit=10):\n",
     "        print('run id {}:, event number: {}'.format(event.get_run_number() , event_id))\n",
     "        print('    Shower energy: {}'.format(event.get_mc_shower_energy()))"
    ]
@@ -165,40 +188,23 @@
     "collapsed": true
    },
    "source": [
-    "### loop ever the 10 first MC event using function move_to_next_mc_event "
+    "### loop over the 10 first MC event using function move_to_next_mc_event "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 8,
+   "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "run id 31964:, event number: 100\n",
-      "    Shower energy: 0.003922517877072096\n",
-      "run id 31964:, event number: 101\n",
-      "    Shower energy: 0.003922517877072096\n",
-      "run id 31964:, event number: 102\n",
-      "    Shower energy: 0.003922517877072096\n",
-      "run id 31964:, event number: 103\n",
-      "    Shower energy: 0.003922517877072096\n",
-      "run id 31964:, event number: 104\n",
-      "    Shower energy: 0.003922517877072096\n",
-      "run id 31964:, event number: 105\n",
-      "    Shower energy: 0.003922517877072096\n",
-      "run id 31964:, event number: 106\n",
-      "    Shower energy: 0.003922517877072096\n",
-      "run id 31964:, event number: 107\n",
-      "    Shower energy: 0.003922517877072096\n",
-      "run id 31964:, event number: 108\n",
-      "    Shower energy: 0.003922517877072096\n",
-      "run id 31964:, event number: 109\n",
-      "    Shower energy: 0.003922517877072096\n"
+     "ename": "AttributeError",
+     "evalue": "'HessioFile' object has no attribute 'fill_next_mc_event'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-8-7b55eccd11cd>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      3\u001b[0m     \u001b[0;32mwhile\u001b[0m \u001b[0mnb_read_event\u001b[0m \u001b[0;34m<\u001b[0m \u001b[0;36m10\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m         \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 5\u001b[0;31m             \u001b[0mevent_id\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mevent\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfill_next_mc_event\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      6\u001b[0m             \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'run id {}:, event number: {}'\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mformat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mevent\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_run_number\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m,\u001b[0m \u001b[0mevent_id\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      7\u001b[0m             \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'    Shower energy: {}'\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mformat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mevent\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_mc_shower_energy\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mAttributeError\u001b[0m: 'HessioFile' object has no attribute 'fill_next_mc_event'"
      ]
     }
    ],
@@ -229,10 +235,11 @@
  ],
  "metadata": {
   "anaconda-cloud": {},
+  "celltoolbar": "Raw Cell Format",
   "kernelspec": {
-   "display_name": "Python [conda env:cta]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-cta-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -244,9 +251,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.5.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/example.ipynb
+++ b/example.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {
     "collapsed": true
    },
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -43,6 +43,42 @@
    ],
    "source": [
     "NumEvents = count_mc_generated_events('pyhessio-extra/datasets/gamma_test_large.simtel.gz')\n",
+    "print(NumEvents)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "400000\n"
+     ]
+    }
+   ],
+   "source": [
+    "NumEvents = count_mc_generated_events('pyhessio-extra/datasets/gamma_20deg_0deg_run10251___cta-prod3-merged_desert-2150m-Paranal-subarray-3_cone10.hdata.gz')\n",
+    "print(NumEvents)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "800000\n"
+     ]
+    }
+   ],
+   "source": [
+    "NumEvents = count_mc_generated_events('pyhessio-extra/datasets/TwoHistogramBlocks.hdata.gz')\n",
     "print(NumEvents)"
    ]
   },
@@ -132,9 +168,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "### loop over the 10 first MC events using generator function move_to_next_event "
    ]
@@ -178,9 +212,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "### loop over the 10 first MC event using function move_to_next_mc_event "
    ]

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: pyhessio
-  version: 2.0.1
+  version: 2.0.2
 
 source:
   git_url: https://github.com/cta-observatory/pyhessio

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: pyhessio
-  version: 2.0.2
+  version: 2.0.3
 
 source:
   git_url: https://github.com/cta-observatory/pyhessio

--- a/pyhessio/__init__.py
+++ b/pyhessio/__init__.py
@@ -11,7 +11,8 @@ from enum import Enum
 
 __all__ = ['HessioError', 'HessioChannelIndexError',
            'HessioTelescopeIndexError', 'HessioGeneralError',
-           'HessioFile', 'open_hessio', 'close_file', 'EventType' ]
+           'HessioFile', 'open_hessio', 'close_file', 'EventType',
+           'count_mc_generated_events']
 
 __version__ = '2.1.0'
 
@@ -77,6 +78,14 @@ def close_file():
     this method to force C library to properly close file a free memory
     """
     lib_close.close_file()
+
+def count_mc_generated_events(filename):
+    """
+    """
+    lib_path = os.path.dirname(__file__)
+    lib = np.ctypeslib.load_library('pyhessioc', lib_path)
+    b_filename = filename.encode('utf-8')
+    return lib.get_mc_num_generated_events(b_filename)
 
 
 class HessioFile:

--- a/pyhessio/src/pyhessio.c
+++ b/pyhessio/src/pyhessio.c
@@ -629,13 +629,23 @@ double get_mc_event_ycore ()
 // Returns number of entries of histogram #6, corresponding to the
 // total number of simulated events, including re-uses of showers
 // If histogram is not found, it returns -1
+// If more than one histogram block is found, the entries of the histogram
+// in the different blocks are added. This is the case e.g. for files
+// resulting from the merging of several simtelarray outputs
 //
 long get_mc_num_generated_events(const char *filename)
 {
     const long excluded[9] = {1, 2, 3, 4, 7, 11, 12, 21, 22};
-    read_histogram_file_x(filename, 0, excluded, 9);
 
     HISTOGRAM* hist = get_histogram_by_ident(6);
+    if (hist)
+        clear_histogram(hist);  // In case it exists from a previous call!
+
+    // read histograms #6 from file, if more than one, add contents:
+    read_histogram_file_x(filename, 1, excluded, 9);
+
+    hist = get_histogram_by_ident(6);
+
     if (!hist){
         Error("Could not find histogram #6 to get number of generated MC events!");
         return -1;
@@ -644,7 +654,7 @@ long get_mc_num_generated_events(const char *filename)
 
     // Get number of entries of the histogram "Events, without weights (Ra3d, log10(E))"
     // This is the real number of Corsika events processed bysimtelarray (_including_ re-uses of each shower!)
-    long numsimushowers = 0.;
+    long numsimushowers = 0;
     int ibin;
     for (ibin = 0; ibin < hist->nbins * hist->nbins_2d; ibin++)
          numsimushowers += he->fdata[ibin];

--- a/pyhessio/src/pyhessio.c
+++ b/pyhessio/src/pyhessio.c
@@ -8,6 +8,7 @@
 #include "io_basic.h"
 #include "io_hess.h"
 #include "io_history.h"
+#include "io_histogram.h"
 #include "fileopen.h"
 #include "stdio.h"
 void close_file (void);
@@ -48,6 +49,7 @@ int move_to_next_mc_event (int *event_id);
 int move_to_next_calib_event (int *event_id);
 double get_mc_event_xcore (void);
 double get_mc_event_ycore (void);
+long get_mc_num_generated_events(const char *filename);
 int get_mc_run_array_direction (double *dir);
 double get_azimuth_raw (int telescope_id);
 double get_altitude_raw (int telescope_id);
@@ -622,6 +624,34 @@ double get_mc_event_ycore ()
 	}
 	return -0.;
 }
+
+//----------------------------------------------------------------
+// Returns number of entries of histogram #6, corresponding to the
+// total number of simulated events, including re-uses of showers
+// If histogram is not found, it returns -1
+//
+long get_mc_num_generated_events(const char *filename)
+{
+    const long excluded[9] = {1, 2, 3, 4, 7, 11, 12, 21, 22};
+    read_histogram_file_x(filename, 0, excluded, 9);
+
+    HISTOGRAM* hist = get_histogram_by_ident(6);
+    if (!hist){
+        Error("Could not find histogram #6 to get number of generated MC events!");
+        return -1;
+    }
+    struct Histogram_Extension *he = hist->extension;
+
+    // Get number of entries of the histogram "Events, without weights (Ra3d, log10(E))"
+    // This is the real number of Corsika events processed bysimtelarray (_including_ re-uses of each shower!)
+    long numsimushowers = 0.;
+    int ibin;
+    for (ibin = 0; ibin < hist->nbins * hist->nbins_2d; ibin++)
+         numsimushowers += he->fdata[ibin];
+
+    return numsimushowers;
+}
+
 //----------------------------------------------------------------
 // Returns B_total
 // Returns -1 if data is not accessible


### PR DESCRIPTION
The information on the number of generated MC events is needed to convert MC event numbers into rates. When more than one histogram block is found, the relevant histograms are added to compute the total number of events.

The function is now a bit slow when working on large files, since the histogram block is at the end of the file. To solve this one can use hessio's  filterio program to extract the histogram block (or blocks, if running on a merge of several simtelarray outputs) like this:

filterio 100 filename.simtel.gz > filename.hdata

Then the necessary histogram can be read much faster from the .hdata file.

I also realize the function is perhaps a bit out of place, it could instead be a function within HessioFile, but  the files can only be opened with the context manager, and it is not clear to me how to make a function which does not provide an event-wise (but file-wise)  information - I guess it is an easy change for an expert.
